### PR TITLE
feat: hashManagerService implemented

### DIFF
--- a/src/model/user/User.ts
+++ b/src/model/user/User.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { UserValidations } from "../validations/UserValidations";
+import HashManagerService from "../../service/hashManager/HashManagerService";
 
 export class User {
   private readonly id: string;
@@ -13,6 +14,7 @@ export class User {
     this.password = password;
     this.email = email;
     UserValidations.ExecUserValidations(this.name, this.password, this.email);
+    this.SetPassword(password);
   }
 
   public GetId() {
@@ -31,8 +33,9 @@ export class User {
     return this.password;
   }
 
-  public SetPassword(newPassword: string) {
-    return (this.password = newPassword);
+  public async SetPassword(newPassword: string) {
+    return this.password = await HashManagerService.generateHash(newPassword)
+
   }
 
   public GetEmail() {

--- a/src/service/hashManager/HashManagerService.ts
+++ b/src/service/hashManager/HashManagerService.ts
@@ -1,0 +1,18 @@
+import * as bcrypt from "bcrypt"
+
+class HashManagerService { 
+
+    generateHash = async (pass: string) :Promise<string> => {
+        const rounds = Number(process.env.BCRYPT_COST)
+        const salt = await bcrypt.genSalt(rounds)
+        const result = await bcrypt.hash(pass, salt)
+
+        return result
+    }
+
+    compareHash = async (pass: string, hash: string) :Promise<boolean> => {
+        return bcrypt.compare(pass, hash)
+    }
+}
+
+export default new HashManagerService() 


### PR DESCRIPTION
# 🚀 Feat: Implement HashManagerService for Password Hashing and Comparison 🚀

## 📘 Adds HashManagerService for securely hashing and verifying user passwords.

### 📌 Finished Tasks
- [x] Implement `HashManagerService` with methods `generateHash` to hash passwords and `compareHash` to verify password matches.
- [x] Integrate `HashManagerService` into the `User` class to hash passwords before saving them.
- [x] Ensure that passwords are securely stored as hashes and not in plaintext.
- [x] Use bcrypt for hashing and comparing passwords with a configurable cost factor.

### 📌 Pending Tasks
- [ ] Tests

Co-authored-by: Aversilucasaversi@gmail.com
